### PR TITLE
Small fixes for current build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voltaire"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Matt Freitas-Stavola <matt.freitas@lifars.com>"]
 
 [dependencies]
@@ -15,7 +15,7 @@ features = [ "suggestions", "color", "yaml" ]
 version = "2"
 default-features = false
 
-features = [ "suggestions", "color", "yaml", "lints" ]
+features = [ "suggestions", "color", "yaml" ]
 
 [profile.dev]
 opt-level = 0

--- a/src/action/scan.rs
+++ b/src/action/scan.rs
@@ -23,7 +23,7 @@ pub fn execute(volatility_path: PathBuf, args: &super::ArgMatches) {
                      "psxview",
                      "consoles",
                      "psscan",
-                     "mutantscan -s",
+                     "mutantscan",
                      "cmdscan",
                      "dlllist",
                      "filescan",

--- a/src/commands.yml
+++ b/src/commands.yml
@@ -1,5 +1,5 @@
 name: voltaire
-version: 0.1.0
+version: 0.1.1
 about: A wrapper for Volatility to make your life easier
 
 # AppSettings can be defined as a list and are **not** ascii case sensitive

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,23 @@ fn fetch_volatility() -> Option<PathBuf> {
     let search_paths = if cfg!(target_os = "windows") {
         vec![r#".\vol.exe"#, r#".\vol.py"#]
     } else {
-        vec!["./vol.py", "/bin/vol.py", "/usr/bin/vol.py", "/usr/local/bin/vol.py"]
+        vec!["/usr/bin/volatility",
+             "./vol",
+             "/bin/vol",
+             "/usr/bin/vol",
+             "/usr/local/bin/vol",
+             "./vol.py",
+             "/bin/vol.py",
+             "/usr/bin/vol.py",
+             "/usr/local/bin/vol.py",
+             "./volatility",
+             "/bin/volatility",
+             "/usr/bin/volatility",
+             "/usr/local/bin/volatility",
+             "./volatility.py",
+             "/bin/volatility.py",
+             "/usr/bin/volatility.py",
+             "/usr/local/bin/volatility.py"]
     };
 
     for test_path in search_paths {
@@ -47,7 +63,8 @@ fn fetch_volatility() -> Option<PathBuf> {
 
         if path.exists() {
             return Some(path);
-        }
+        };
+        panic!("Unable to find volatility executable. Please use -p.")
     }
 
     None


### PR DESCRIPTION
- Removed `lints` from `dev-dependencies.clap` since it is broken and will prevent you from compiling.
- Added more paths for non-windows users
- Added a panic message in case `fetch_volatility` fails
- Removed `-s` from `mutantscan` since passing volatility arguments through the tests vec does not work. Submitted a issue on this.
- Changed our version to 0.1.1. Progress!
